### PR TITLE
Update reviewer_progress_bar.py

### DIFF
--- a/reviewer_progress_bar.py
+++ b/reviewer_progress_bar.py
@@ -347,7 +347,7 @@ def updatePB():
 
         # showInfo("pbMax = %d, pbValue = %d" % (pbMax, pbValue))
     var_diff = pbMax - pbValue
-    progbarmax = var_diff + cards
+    progbarmax = int(var_diff + cards)
 
     speed = (cards / max(1, thetime)) * 60
     secspeed = max(1, thetime) / max(1, cards)


### PR DESCRIPTION
Update for python 3.11

In python 3.11, eg Fedora Linux or Debian 12, progbarmax is treated as a float and the add-on is broken. This MR fixes that